### PR TITLE
Added depend flag in Robinhq_Hooks.xml so that magento fails if Jowen…

### DIFF
--- a/app/etc/modules/Robinhq_Hooks.xml
+++ b/app/etc/modules/Robinhq_Hooks.xml
@@ -5,6 +5,9 @@
             <active>true</active>
             <codePool>community</codePool>
             <version>0.0.1</version>
+            <depends>
+                <Jowens_JobQueue />
+            </depends>
         </Robinhq_Hooks>
     </modules>
 </config>


### PR DESCRIPTION
…s_JobQueue is not present in installation (Branch: feature/break-on-not-meeting-dependencies)