### PR TITLE
Fix exception generation on request failure

### DIFF
--- a/app/code/community/Robinhq/Hooks/Model/Exception/RequestFailed.php
+++ b/app/code/community/Robinhq/Hooks/Model/Exception/RequestFailed.php
@@ -37,6 +37,6 @@ class Robinhq_Hooks_Model_Exception_RequestFailed
 
         }
 
-        return Mage::getModel('robinhq_hooks/exception_' . $errorModel);
+        return Mage::getModel('robinhq_hooks/exception_' . $errorModel, '');
     }
 }


### PR DESCRIPTION
The module was getting status 500 from the RobinHQ api, resulting in generating an exception. The exception generated however, failed with the following error:
```
PHP Fatal error:  Uncaught Error: Wrong parameters for Robinhq_Hooks_Model_Exception_InternalServerErrorException([string $message [, long $code [, Throwable $previous = NULL]]]) in app/code/core/Mage/Core/Model/Config.php:1357
```